### PR TITLE
Correct types for valid options added via convenience methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "typescript": "^5.2.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"

--- a/package.json
+++ b/package.json
@@ -91,5 +91,8 @@
   "author": "Isaac Z. Schlueter <i@izs.me>",
   "optionalDependencies": {
     "@pkgjs/parseargs": "^0.11.0"
+  },
+  "tap": {
+    "typecheck": true
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,7 @@ export type ConfigSetFromMetaSet<
   M extends boolean,
   S extends ConfigMetaSet<T, M>,
 > = {
-  [longOption in keyof S]: ConfigOptionBase<T, M>
+  [longOption in keyof S]: ConfigOptionBase<T, M> & S[longOption]
 }
 
 /**
@@ -1168,6 +1168,7 @@ export class Jack<C extends ConfigSet = {}> {
     if (this.#usage) return this.#usage
 
     let headingLevel = 1
+    //@ts-ignore
     const ui = cliui({ width })
     const first = this.#fields[0]
     let start = first?.type === 'heading' ? 1 : 0

--- a/tap-snapshots/test/basic.ts.test.cjs
+++ b/tap-snapshots/test/basic.ts.test.cjs
@@ -387,13 +387,22 @@ exports[`TAP > TAP > validate against options > must match snapshot 1`] = `
 Usage:
   foo [options] <files>
 
-  --vo-opt=<vo-opt>  Valid options: "x", "y"
+  --vo-opt=<vo-opt>    Valid options: "x", "y"
   --vo-optlist=<vo-optlist>
-                     Valid options: "x", "y"
-                     Can be set multiple times
-  --vo-num=<n>       Valid options: 1, 2
-  --vo-numlist=<n>   Valid options: 1, 2
-                     Can be set multiple times
+                       Valid options: "x", "y"
+                       Can be set multiple times
+  --vo-num=<n>         Valid options: 1, 2
+  --vo-numlist=<n>     Valid options: 1, 2
+                       Can be set multiple times
+  --vo-by-opt=<vo-by-opt>
+                       Valid options: "x", "y"
+
+  --vo-by-optlist=<vo-by-optlist>
+                       Valid options: "x", "y"
+                       Can be set multiple times
+  --vo-by-num=<n>      Valid options: 1, 2
+  --vo-by-numlist=<n>  Valid options: 1, 2
+                       Can be set multiple times
 `
 
 exports[`test/basic.ts --foo > TAP > defaults to process.env and process.argv > default parse, no _eval 1`] = `

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -330,7 +330,7 @@ t.test('stop at positional', t => {
 
 t.test('stop at positional test', t => {
   const { values, positionals } = jack({
-    stopAtPositionalTest: s => s === 'stop'
+    stopAtPositionalTest: s => s === 'stop',
   })
     .num({ xyz: {} })
     .parse(['--xyz=1', 'positional', '--xyz=2', 'stop', '--otherthing=x'])
@@ -400,35 +400,64 @@ t.test('validate against options', t => {
     usage: 'foo [options] <files>',
     env: t.context.env,
     envPrefix: 'TEST',
-  }).addFields({
-    'vo-opt': {
-      type: 'string',
-      validOptions: ['x', 'y'] as const,
-    },
-    'vo-optlist': {
-      type: 'string',
-      multiple: true,
-      validOptions: ['x', 'y'] as const,
-    },
-    'vo-num': {
-      type: 'number',
-      validOptions: [1, 2] as const,
-    },
-    'vo-numlist': {
-      type: 'number',
-      multiple: true,
-      validOptions: [1, 2] as const,
-    },
   })
+    .addFields({
+      'vo-opt': {
+        type: 'string',
+        validOptions: ['x', 'y'] as const,
+      },
+      'vo-optlist': {
+        type: 'string',
+        multiple: true,
+        validOptions: ['x', 'y'] as const,
+      },
+      'vo-num': {
+        type: 'number',
+        validOptions: [1, 2] as const,
+      },
+      'vo-numlist': {
+        type: 'number',
+        multiple: true,
+        validOptions: [1, 2] as const,
+      },
+    })
+    .opt({
+      'vo-by-opt': {
+        validOptions: ['x', 'y'] as const,
+      },
+    })
+    .optList({
+      'vo-by-optlist': {
+        validOptions: ['x', 'y'] as const,
+      },
+    })
+    .num({
+      'vo-by-num': {
+        validOptions: [1, 2] as const,
+      },
+    })
+    .numList({
+      'vo-by-numlist': {
+        validOptions: [1, 2] as const,
+      },
+    })
   t.throws(() => j.validate({ 'vo-opt': 'a' }))
   t.throws(() => j.validate({ 'vo-optlist': ['a'] }))
   t.throws(() => j.validate({ 'vo-num': 9 }))
   t.throws(() => j.validate({ 'vo-numlist': [9] }))
+  t.throws(() => j.validate({ 'vo-by-opt': 'a' }))
+  t.throws(() => j.validate({ 'vo-by-optlist': ['a'] }))
+  t.throws(() => j.validate({ 'vo-by-num': 9 }))
+  t.throws(() => j.validate({ 'vo-by-numlist': [9] }))
   j.validate({
     'vo-opt': 'x',
     'vo-optlist': ['y'],
     'vo-num': 1,
     'vo-numlist': [2],
+    'vo-by-opt': 'x',
+    'vo-by-optlist': ['y'],
+    'vo-by-num': 1,
+    'vo-by-numlist': [2],
   }) as void
 
   // invalid validOptions
@@ -440,6 +469,17 @@ t.test('validate against options', t => {
   t.throws(() => j.opt({ n: { validOptions: [1] } }))
   //@ts-expect-error
   t.throws(() => j.optList({ n: { validOptions: [1] } }))
+
+  // types
+  const { values } = j.parse()
+  const _voOpt: 'x' | 'y' = values['vo-opt']!
+  const _voOptList: ('x' | 'y')[] = values['vo-optlist']!
+  const _voNum: 1 | 2 = values['vo-num']!
+  const _voNumList: (1 | 2)[] = values['vo-numlist']!
+  const _opt: 'x' | 'y' = values['vo-by-opt']!
+  const _optList: ('x' | 'y')[] = values['vo-by-optlist']!
+  const _num: 1 | 2 = values['vo-by-num']!
+  const _numList: (1 | 2)[] = values['vo-by-numlist']!
 
   t.equal(
     isConfigOption(
@@ -504,7 +544,7 @@ t.test('parseRaw', t => {
     xyz: {
       default: 345,
       validate: (n: unknown) => Number(n) % 2 === 1,
-    }
+    },
   })
   const p = j.parseRaw(['--xyz=235'])
   t.equal(p.values.xyz, 235)
@@ -516,10 +556,9 @@ t.test('parseRaw', t => {
 })
 
 t.test('description with fenced code blocks', t => {
-  const j = jack({})
-    .num({
-      xyz: {
-        description: `Sometimes, there's a number and you care about
+  const j = jack({}).num({
+    xyz: {
+      description: `Sometimes, there's a number and you care about
                       doing something special with that number, like
 
                       \`\`\`
@@ -542,9 +581,9 @@ t.test('description with fenced code blocks', t => {
                       nothing in this one:
                       \`\`\`
         \`\`\`
-                      `
-      },
-    })
+                      `,
+    },
+  })
   t.matchSnapshot(j.usage())
   t.end()
 })


### PR DESCRIPTION
Stumbled on this as a solution for getting the correct types for configs with `validOptions` that are added by the convenience methods such as `opt`.

Made a stripped down TypeScript playground to illustrate the fix in case it's helpful to play around with other possible fixes. [Playground](https://www.typescriptlang.org/play/?moduleResolution=99&target=10&module=199#code/C4TwDgpgBA8mwEsD2A7KBeKBvAsAKCigDcBDAGwQBMAuKAJwhMtTJCgGdg6EUBzAbQC6+AL758oSFADCqAGYJeGbPkL8A1rU7c+g2nESpR4vJOiyUC3gHEIKCNwDGAHgAqUCAA9gdyuxnyigB8yrgEUBpQPFDqECBIclCuerDwyCjGeBLg5oE2dg4IjgCSKD507BCOhihuHt6+-hZWIZhhaupRaLHxicn6aahQAGRJGsJ4YlmmOVAAShDsAK5kwHVePih+AZbBoaoRndE9CUkpruP8AESkFJRXgvWb2wxMLGzaPAKPAPxj6oJrrcqA9+CglgBbABGDkeWi4X0y+EcqE4UDAJAqEAAgsp1g0tk08kEABQAfQUEDIflorgAlBgQiSsCIGSR-AtlqtnM1FCMkkFkajgOjMZUAEJ49wbRo7FrkynU9i0hnoJkstkcxYrNa8pSjPW2exONxBQV4FEoNEYrHSKVPWV60kUhBUmlJVXq1lQdnzbXcvX8w0FJylcqVarpU3moVWkWJNoxWhYYjkKi0a6eK4AGigVxADx9-ktaJEUCmJZFJFoJLMpzkADp1A3gZQ6WDITC6I9MDbKtiSXI6U38AB6UeESdT6cz2dz+dQAB6P1jaKhNbriUbzdb7fB0Nhyj7EHFg+H6jHE4X15v1+Xq5Fjg3OXrTZbabbHYP3aPYog0jPEc8HHW9QLAyd7zwIA)
